### PR TITLE
Fix retriever stats fetching bug

### DIFF
--- a/memvid/chat.py
+++ b/memvid/chat.py
@@ -20,14 +20,14 @@ class MemvidChat:
     """Enhanced MemvidChat with multi-provider LLM support"""
 
     def __init__(
-            self,
-            video_file: str,
-            index_file: str,
-            llm_provider: str = 'google',
-            llm_model: str = None,
-            llm_api_key: str = None,
-            config: Optional[Dict] = None,
-            retriever_kwargs: Dict = None
+        self,
+        video_file: str,
+        index_file: str,
+        llm_provider: str = "google",
+        llm_model: str = None,
+        llm_api_key: str = None,
+        config: Optional[Dict] = None,
+        retriever_kwargs: Dict = None,
     ):
         """
         Initialize MemvidChat with flexible LLM provider support
@@ -51,11 +51,7 @@ class MemvidChat:
 
         # Initialize LLM client
         try:
-            self.llm_client = LLMClient(
-                provider=llm_provider,
-                model=llm_model,
-                api_key=llm_api_key
-            )
+            self.llm_client = LLMClient(provider=llm_provider, model=llm_model, api_key=llm_api_key)
             self.llm_provider = llm_provider
             logger.info(f"✓ Initialized {llm_provider} LLM client")
         except Exception as e:
@@ -143,12 +139,13 @@ The context will be provided with each query based on semantic similarity to the
             context_chunks = self.retriever.search(query, top_k=self.context_chunks)
 
             # Join chunks into context string
-            context = "\n\n".join([f"[Context {i+1}]: {chunk}"
-                                   for i, chunk in enumerate(context_chunks)])
+            context = "\n\n".join(
+                [f"[Context {i+1}]: {chunk}" for i, chunk in enumerate(context_chunks)]
+            )
 
             # Rough token limiting (4 chars ≈ 1 token)
             if len(context) > max_tokens * 4:
-                context = context[:max_tokens * 4] + "..."
+                context = context[: max_tokens * 4] + "..."
 
             return context
         except Exception as e:
@@ -218,7 +215,9 @@ User question: {message}"""
 
             response = "Based on the knowledge base, here's what I found:\n\n"
             for i, chunk in enumerate(context_chunks[:3]):  # Limit to top 3
-                response += f"{i+1}. {chunk[:200]}...\n\n" if len(chunk) > 200 else f"{i+1}. {chunk}\n\n"
+                response += (
+                    f"{i+1}. {chunk[:200]}...\n\n" if len(chunk) > 200 else f"{i+1}. {chunk}\n\n"
+                )
 
             return response.strip()
 
@@ -243,7 +242,7 @@ User question: {message}"""
             try:
                 user_input = input("\nYou: ").strip()
 
-                if user_input.lower() in ['quit', 'exit', 'q']:
+                if user_input.lower() in ["quit", "exit", "q"]:
                     # Export conversation before exiting
                     if self.conversation_history:
                         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -252,11 +251,11 @@ User question: {message}"""
                     print("Goodbye!")
                     break
 
-                elif user_input.lower() == 'clear':
+                elif user_input.lower() == "clear":
                     self.clear_history()
                     continue
 
-                elif user_input.lower() == 'stats':
+                elif user_input.lower() == "stats":
                     stats = self.get_stats()
                     print(f"Session stats: {stats}")
                     continue
@@ -305,17 +304,17 @@ User question: {message}"""
         Path(path).parent.mkdir(parents=True, exist_ok=True)
 
         conversation_data = {
-            'session_id': self.session_id,
-            'system_prompt': self.system_prompt,
-            'llm_provider': self.llm_provider,
-            'conversation': self.conversation_history,
-            'video_file': self.video_file,
-            'index_file': self.index_file,
-            'timestamp': datetime.now().isoformat(),
-            'stats': self.get_stats()
+            "session_id": self.session_id,
+            "system_prompt": self.system_prompt,
+            "llm_provider": self.llm_provider,
+            "conversation": self.conversation_history,
+            "video_file": self.video_file,
+            "index_file": self.index_file,
+            "timestamp": datetime.now().isoformat(),
+            "stats": self.get_stats(),
         }
 
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(conversation_data, f, indent=2, ensure_ascii=False)
 
         print(f"Conversation exported to {path}")
@@ -327,7 +326,7 @@ User question: {message}"""
         Args:
             session_file: Path to session file
         """
-        with open(session_file, 'r', encoding='utf-8') as f:
+        with open(session_file, "r", encoding="utf-8") as f:
             session_data = json.load(f)
 
         self.session_id = session_data.get("session_id")
@@ -345,20 +344,26 @@ User question: {message}"""
     def get_stats(self) -> Dict:
         """Get stats about the current session"""
         return {
-            'session_id': self.session_id,
-            'messages_exchanged': len(self.conversation_history),
-            'llm_provider': self.llm_provider,
-            'llm_available': self.llm_client is not None,
-            'video_file': self.video_file,
-            'index_file': self.index_file,
-            'context_chunks_per_query': self.context_chunks,
-            'max_history': self.max_history
+            "session_id": self.session_id,
+            "messages_exchanged": len(self.conversation_history),
+            "llm_provider": self.llm_provider,
+            "llm_available": self.llm_client is not None,
+            "video_file": self.video_file,
+            "index_file": self.index_file,
+            "context_chunks_per_query": self.context_chunks,
+            "max_history": self.max_history,
+            "retriever_stats": self.retriever.get_stats(),
         }
 
 
 # Backwards compatibility aliases
-def chat_with_memory(video_file: str, index_file: str, api_key: str = None,
-                     provider: str = 'google', model: str = None):
+def chat_with_memory(
+    video_file: str,
+    index_file: str,
+    api_key: str = None,
+    provider: str = "google",
+    model: str = None,
+):
     """
     Quick chat function for backwards compatibility
 
@@ -374,14 +379,15 @@ def chat_with_memory(video_file: str, index_file: str, api_key: str = None,
         index_file=index_file,
         llm_provider=provider,
         llm_model=model,
-        llm_api_key=api_key
+        llm_api_key=api_key,
     )
 
     chat.interactive_chat()
 
 
-def quick_chat(video_file: str, index_file: str, message: str,
-               provider: str = 'google', api_key: str = None) -> str:
+def quick_chat(
+    video_file: str, index_file: str, message: str, provider: str = "google", api_key: str = None
+) -> str:
     """
     Quick single message chat
 
@@ -396,10 +402,7 @@ def quick_chat(video_file: str, index_file: str, message: str,
         Response from the assistant
     """
     chat = MemvidChat(
-        video_file=video_file,
-        index_file=index_file,
-        llm_provider=provider,
-        llm_api_key=api_key
+        video_file=video_file, index_file=index_file, llm_provider=provider, llm_api_key=api_key
     )
 
     return chat.chat(message)


### PR DESCRIPTION
There is a [bug](https://github.com/Olow304/memvid/issues/26) with fetching the stats for a chat session which is preventing users from running simple flows. Fixed by passing the retriever's stats to the chat stat output.