### PR TITLE
Add hugging Face as a Provider

### DIFF
--- a/memvid.egg-info/PKG-INFO
+++ b/memvid.egg-info/PKG-INFO
@@ -38,6 +38,7 @@ Provides-Extra: llm
 Requires-Dist: openai>=1.0.0; extra == "llm"
 Requires-Dist: google-generativeai>=0.8.0; extra == "llm"
 Requires-Dist: anthropic>=0.52.0; extra == "llm"
+Requires-Dist: huggingface_hub>=0.32.0; extra == "llm"
 Provides-Extra: epub
 Requires-Dist: beautifulsoup4>=4.0.0; extra == "epub"
 Requires-Dist: ebooklib>=0.18; extra == "epub"
@@ -150,7 +151,7 @@ pip install PyPDF2
 from memvid import MemvidEncoder, MemvidChat
 
 # Create video memory from text chunks
-chunks = ["Important fact 1", "Important fact 2", "Historical event details", ...]
+chunks = ["Important fact 1", "Important fact 2", "Historical event details"]
 encoder = MemvidEncoder()
 encoder.add_chunks(chunks)
 encoder.build_video("memory.mp4", "memory_index.json")

--- a/memvid.egg-info/requires.txt
+++ b/memvid.egg-info/requires.txt
@@ -23,6 +23,7 @@ ebooklib>=0.18
 openai>=1.0.0
 google-generativeai>=0.8.0
 anthropic>=0.52.0
+huggingface_hub>=0.32.0
 
 [web]
 fastapi>=0.100.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ ebooklib
 openai==1.82.0
 google-generativeai==0.8.5
 anthropic~=0.52.1
+huggingface_hub>=0.32.0

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             "openai>=1.0.0",
             "google-generativeai>=0.8.0",
             "anthropic>=0.52.0",
+            "huggingface_hub>=0.32.0",
         ],
         "epub": [
             "beautifulsoup4>=4.0.0",


### PR DESCRIPTION
Hi there, I'm Célina from Hugging Face 🤗,
This PR introduces support for Hugging Face's Inference Providers (documentation [here](https://huggingface.co/docs/inference-providers/index)) as a LLM provider.

Our API is fully aligned with the OpenAI REST API specs so I mainly followed the existing `OpenAIProvider` implementation.
I don't think there are tests of LLM providers, so I tested the integration by running the script examples:

```python
import os

from memvid.chat import MemvidChat
from memvid.encoder import MemvidEncoder

chunks = ["Important fact 1", "Important fact 2", "Historical event details"]
encoder = MemvidEncoder()
encoder.add_chunks(chunks)
encoder.build_video("memory.mp4", "memory_index.json")

# Chat with your memory
chat = MemvidChat("memory.mp4", "memory_index.json", llm_provider="huggingface")
chat.start_session()
response = chat.chat("What do you know about historical events?")
print(response)

```


Looking forward to your feedback!

cc @Wauplin for viz