### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/Olow304/memvid?lang=de) | 
+[Español](https://www.readme-i18n.com/Olow304/memvid?lang=es) | 
+[français](https://www.readme-i18n.com/Olow304/memvid?lang=fr) | 
+[日本語](https://www.readme-i18n.com/Olow304/memvid?lang=ja) | 
+[한국어](https://www.readme-i18n.com/Olow304/memvid?lang=ko) | 
+[Português](https://www.readme-i18n.com/Olow304/memvid?lang=pt) | 
+[Русский](https://www.readme-i18n.com/Olow304/memvid?lang=ru) | 
+[中文](https://www.readme-i18n.com/Olow304/memvid?lang=zh)
+
 Memvid revolutionizes AI memory management by encoding text data into videos, enabling **lightning-fast semantic search** across millions of text chunks with **sub-second retrieval times**. Unlike traditional vector databases that consume massive amounts of RAM and storage, Memvid compresses your knowledge base into compact video files while maintaining instant access to any piece of information.
 
 ## 🎥 Demo


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.